### PR TITLE
Remove perl6.party Feed

### DIFF
--- a/perlanetrc
+++ b/perlanetrc
@@ -68,9 +68,6 @@ feeds:
  -  url: http://independentcomputing.biz/tag/perl6/rss/
     title: Independent Computing
     web: http://independentcomputing.biz/tag/perl6/rss/
- -  url: http://perl6.party/feed/
-    title: Zoffix Znet
-    web: http://perl6.party/
  -  url: http://hoelz.ro/perl6.rss
     title: hoelzro
     web: http://hoelz.ro/


### PR DESCRIPTION
No longer posting Raku content on the site and I foresee a possibility of
non-Raku, non-programming articles being posted on the site, which will
be weird for them to show up in the pl6anet.org feed and raku.org home
page that pulls from that feed.