### PR TITLE
Remove bbkr feed

### DIFF
--- a/perlanetrc
+++ b/perlanetrc
@@ -32,9 +32,6 @@ feeds:
  -  feed: https://dev.to/feed/lizmat
     title: Elizabeth Mattijsen
     web: https://dev.to/lizmat
- -  feed: http://dev.to/feed/bbkr
-    title: Paweł bbkr Pabian
-    web: http://dev.to/bbkr
  -  feed:  http://brrt-to-the-future.blogspot.com/feeds/posts/default/-/perl6
     title: brrt to the future
     web: http://brrt-to-the-future.blogspot.com/feeds/posts/default/-/perl6


### PR DESCRIPTION
I want to make series of posts on dev.to not related to Raku and I do not want to spam planet.raku.org namespace. For Raku posts I use tags, which are more precise that copy-pasting whole stream.